### PR TITLE
Force Rust to actually carry out the computation

### DIFF
--- a/rust/leapfrog.rs
+++ b/rust/leapfrog.rs
@@ -16,8 +16,9 @@ fn main() {
         gravity_calculate_acceleration(N_PARTICLES, &m, &x, &mut a);
         integrator_leapfrog_part2(N_PARTICLES, &mut x, &mut v, &a, time_step, half_time_step);
         time += half_time_step;
-    } 
+    }
     //println!("Hello, world!");
+    println!("{:?}", x)
 }
 
 fn integrator_leapfrog_part1(n_particles: usize, x: &mut [[f64; 3]; N_PARTICLES], v: &[[f64; 3]; N_PARTICLES], half_time_step: f64) {
@@ -60,4 +61,3 @@ fn gravity_calculate_acceleration(n_particles: usize, m: &[f64; 3], x: &[[f64; 3
         }
 	}
 }
-


### PR DESCRIPTION
Currently, this benchmark only times Rust's ability to count to a year. Printing one of the final positions forces the actual simulation to run.

On my machine this takes the timings from ~10s to ~130s, closer to C. Presumably the Fortran code needs the same fix.