### PR TITLE
Fortran version improvements

### DIFF
--- a/fortran/Makefile
+++ b/fortran/Makefile
@@ -2,11 +2,11 @@
 all: target/not_optimized/leapfrog target/optimized/leapfrog
 
 target/not_optimized/leapfrog: leapfrog.f90 target/not_optimized/
-	gfortran -O0 -finit-real=nan leapfrog.f90 -o target/not_optimized/leapfrog
+	gfortran -O0 -finit-real=nan -fdefault-real-8 leapfrog.f90 -o target/not_optimized/leapfrog
 	echo "run: time target/not_optimized/leapfrog"
 
 target/optimized/leapfrog: leapfrog.f90 target/optimized/
-	gfortran -O3 -finit-real=nan leapfrog.f90 -o target/optimized/leapfrog
+	gfortran -O3 -finit-real=nan -fdefault-real-8 leapfrog.f90 -o target/optimized/leapfrog
 	echo "run: time target/optimized/leapfrog"
 
 target/optimized/:

--- a/fortran/leapfrog.f90
+++ b/fortran/leapfrog.f90
@@ -1,139 +1,41 @@
-
 program leapfrog
     implicit none
 
-    integer :: n_particles
-    integer :: error
-    real, dimension(:), allocatable :: m
-    real, dimension(:,:), allocatable :: x, v, a
-    real :: time, time_step, time_limit, half_time_step, time_write
+    integer, parameter :: n_particles = 2
+    real, dimension(n_particles) :: m
+    real, dimension(3,n_particles) :: x, v, a
+    real, dimension(3) :: dR
+    real :: t, dt, t_end, r2
+    real, parameter :: G = 6.6742367e-11 ! m^3.kg^-1.s^-2
+    integer :: i
 
-    n_particles = 2
-    time = 0
-    time_write = 0
-    time_step = 0.08d0 ! in days
-    time_limit = 365.25d0 * 1.d6
-    allocate(m(n_particles), stat=error)
-    allocate(x(3,n_particles), stat=error)
-    allocate(v(3,n_particles), stat=error)
-    allocate(a(3,n_particles), stat=error)
-    m(1:n_particles) = 0.0d0
-    x(1,1:n_particles) = 0.0d0
-    x(2,1:n_particles) = 0.0d0
-    x(3,1:n_particles) = 0.0d0
-    v(1,1:n_particles) = 0.0d0
-    v(2,1:n_particles) = 0.0d0
-    v(3,1:n_particles) = 0.0d0
-    a(1,1:n_particles) = 0.0d0
-    a(2,1:n_particles) = 0.0d0
-    a(3,1:n_particles) = 0.0d0
-    m(1) = 0.08 ! M_SUN
-    m(2) = 3.0e-6 ! M_SUN
-    x(1, 2) = 0.0162 ! AU
-    x(2, 2) = 6.57192058353e-15 ! AU
-    x(3, 2) = 5.74968548652e-16 ! AU
-    v(1, 2) = -1.48427302304e-14
-    v(2, 2) = 0.0399408809121
-    v(3, 2) = 0.00349437429104
+    t = 0
+    dt = 0.08 ! time step, days
+    t_end = 365.25e6 ! days
+    ! Set initial conditions
+    m(:) = (/0.08,3.0e-6/) ! M_SUN
+    x(:,1) = 0.0
+    x(:,2) = (/0.0162,6.57192058353e-15,5.74968548652e-16/) ! AU
+    v(:,1) = 0.0
+    v(:,2) = (/-1.48427302304e-14,0.0399408809121,0.00349437429104/)
+    a(:,:) = 0.0
 
-    half_time_step = 0.5d0*time_step
-    do while (time.le.time_limit)
-        call integrator_leapfrog_part1(n_particles,x,v,half_time_step)
-        time = time + half_time_step
-        call gravity_calculate_acceleration(n_particles,m,x,a)
-        call integrator_leapfrog_part2(n_particles,x,v,a,time_step,half_time_step)
-        time = time + half_time_step
-        !if (time.ge.time_write) then
-            !write(*,*) time
-            !time_write = time_write + 100.*365.25d0
-        !endif
+    do while (t <= t_end)
+        ! First step of leapfrog
+        x = x + 0.5*dt*v
+        t = t + 0.5*dt
+
+        ! Compute forces
+        dR(:) = x(:,1) - x(:,2)
+        r2 = sqrt(sum(dR**2))
+        a(:,1) = -G*m(2)/(r2*r2*r2) * dR
+        a(:,2) = -a(:,1) ! Newton's third law
+
+        ! Second step of leapfrog
+        v = v + dt*a
+        x = x + 0.5*dt*v
+        t = t + 0.5*dt
     enddo
     write(*,*) x
 
-
 end program leapfrog
-
-subroutine integrator_leapfrog_part1(n_particles,x,v,half_time_step)
-    implicit none
-
-    ! Input/Output
-    integer,intent(in) :: n_particles
-    real,intent(out) :: x(3,n_particles)
-    real,intent(in) :: v(3,n_particles)
-    real,intent(in) :: half_time_step
-
-    ! Local
-    integer :: i
-
-    do i=1,n_particles
-        ! Positions
-        x(1,i) = x(1,i) + half_time_step * v(1,i)
-        x(2,i) = x(2,i) + half_time_step * v(2,i)
-        x(3,i) = x(3,i) + half_time_step * v(3,i)
-    enddo
-end subroutine integrator_leapfrog_part1
-
-subroutine integrator_leapfrog_part2(n_particles,x,v,a,time_step,half_time_step)
-    implicit none
-
-    ! Input/Output
-    integer,intent(in) :: n_particles
-    real,intent(out) :: x(3,n_particles), v(3,n_particles)
-    real,intent(in) :: a(3,n_particles)
-    real,intent(in) :: time_step, half_time_step
-
-    ! Local
-    integer :: i
-
-    do i=1,n_particles
-        ! Velocities
-        v(1,i) = v(1,i) + time_step * a(1,i)
-        v(2,i) = v(2,i) + time_step * a(2,i)
-        v(3,i) = v(3,i) + time_step * a(3,i)
-
-        ! Positions
-        x(1,i) = x(1,i) + half_time_step * v(1,i)
-        x(2,i) = x(2,i) + half_time_step * v(2,i)
-        x(3,i) = x(3,i) + half_time_step * v(3,i)
-    enddo
-end subroutine integrator_leapfrog_part2
-
-subroutine gravity_calculate_acceleration(n_particles,m,x,a_grav)
-    implicit none
-
-    ! Input/Output
-    integer,intent(in) :: n_particles
-    real,intent(in) :: x(3,n_particles)
-    real,intent(in) :: m(n_particles)
-    real, intent(out) :: a_grav(3,n_particles)
-
-    ! Local
-    integer :: i,j
-    real :: dx,dy,dz,rr,prefact,G
-    !-------------------------------------------------------------------------
-
-    G = 6.6742367e-11 ! m^3.kg^-1.s^-2
-    do i = 1,n_particles
-        ! Initialization
-        a_grav(1,i) = 0.0d0 
-        a_grav(2,i) = 0.0d0 
-        a_grav(3,i) = 0.0d0 
-
-        do j = 1,n_particles
-            if (i.ne.j) then
-                dx = x(1,i) - x(1,j)
-                dy = x(2,i) - x(2,j)
-                dz = x(3,i) - x(3,j)
-                rr = sqrt(dx*dx + dy*dy + dz*dz)
-                prefact = -G*m(j)/(rr*rr*rr)
-
-                a_grav(1,i) =  a_grav(1,i) + prefact * dx 
-                a_grav(2,i) =  a_grav(2,i) + prefact * dy 
-                a_grav(3,i) =  a_grav(3,i) + prefact * dz 
-            endif
-        enddo
-    enddo
-
-    !-------------------------------------------------------------------------
-    return
-end subroutine gravity_calculate_acceleration

--- a/fortran/leapfrog.f90
+++ b/fortran/leapfrog.f90
@@ -4,9 +4,9 @@ program leapfrog
 
     integer :: n_particles
     integer :: error
-    real(selected_real_kind(15,307)), dimension(:), allocatable :: m
-    real(selected_real_kind(15,307)), dimension(:,:), allocatable :: x, v, a
-    real(selected_real_kind(15,307)) :: time, time_step, time_limit, half_time_step, time_write
+    real, dimension(:), allocatable :: m
+    real, dimension(:,:), allocatable :: x, v, a
+    real :: time, time_step, time_limit, half_time_step, time_write
 
     n_particles = 2
     time = 0
@@ -58,9 +58,9 @@ subroutine integrator_leapfrog_part1(n_particles,x,v,half_time_step)
 
     ! Input/Output
     integer,intent(in) :: n_particles
-    real(selected_real_kind(15,307)),intent(out) :: x(3,n_particles)
-    real(selected_real_kind(15,307)),intent(in) :: v(3,n_particles)
-    real(selected_real_kind(15,307)),intent(in) :: half_time_step
+    real,intent(out) :: x(3,n_particles)
+    real,intent(in) :: v(3,n_particles)
+    real,intent(in) :: half_time_step
 
     ! Local
     integer :: i
@@ -78,9 +78,9 @@ subroutine integrator_leapfrog_part2(n_particles,x,v,a,time_step,half_time_step)
 
     ! Input/Output
     integer,intent(in) :: n_particles
-    real(selected_real_kind(15,307)),intent(out) :: x(3,n_particles), v(3,n_particles)
-    real(selected_real_kind(15,307)),intent(in) :: a(3,n_particles)
-    real(selected_real_kind(15,307)),intent(in) :: time_step, half_time_step
+    real,intent(out) :: x(3,n_particles), v(3,n_particles)
+    real,intent(in) :: a(3,n_particles)
+    real,intent(in) :: time_step, half_time_step
 
     ! Local
     integer :: i
@@ -103,13 +103,13 @@ subroutine gravity_calculate_acceleration(n_particles,m,x,a_grav)
 
     ! Input/Output
     integer,intent(in) :: n_particles
-    real(selected_real_kind(15,307)),intent(in) :: x(3,n_particles)
-    real(selected_real_kind(15,307)),intent(in) :: m(n_particles)
-    real(selected_real_kind(15,307)), intent(out) :: a_grav(3,n_particles)
+    real,intent(in) :: x(3,n_particles)
+    real,intent(in) :: m(n_particles)
+    real, intent(out) :: a_grav(3,n_particles)
 
     ! Local
     integer :: i,j
-    real(selected_real_kind(15,307)) :: dx,dy,dz,rr,prefact,G
+    real :: dx,dy,dz,rr,prefact,G
     !-------------------------------------------------------------------------
 
     G = 6.6742367e-11 ! m^3.kg^-1.s^-2


### PR DESCRIPTION
As promised, a PR to make the Fortran version less ugly and slow. The explanations in the commit messages should be pretty thorough. 

On my machine, the Fortran version is now 22% faster than the C version; the previous version was 12% slower. I don't have a Rust compiler installed, but this indicates the Fortran version should now be the fastest of the bunch.

The new version is 35 SLOC, while the old version was 117 SLOC.

The output of the final particle positions are correct.